### PR TITLE
Rename parts of psi for clarity

### DIFF
--- a/InitialConditionSolver/Source/MultigridUserVariables.hpp
+++ b/InitialConditionSolver/Source/MultigridUserVariables.hpp
@@ -9,7 +9,9 @@
 // assign an enum to each variable
 enum
 {
-    c_psi,
+    c_psi_reg, // the regular part of psi_0 not including the singular
+               // Brill-Lindquist part which is added separately
+               // See Alcubierre p112 eq. (3.4.29)
 
     c_A11_0,
     c_A12_0,

--- a/InitialConditionSolver/Source/SetBinaryBH.H
+++ b/InitialConditionSolver/Source/SetBinaryBH.H
@@ -89,7 +89,9 @@ void set_binary_bh_Aij(FArrayBox &multigrid_vars_box, const IntVect &iv,
         get_Aij(1, 2, rbh1, rbh2, n1, n2, J1, J2, P1, P2, a_params);
 }
 
-Real get_binary_bh_psi(const RealVect &loc, const PoissonParameters &a_params)
+// returns the Brill-Lindquist (singular) part of psi
+Real get_psi_brill_lindquist(const RealVect &loc,
+                             const PoissonParameters &a_params)
 {
     // the Bowen York params
     Real m1 = a_params.bh1_bare_mass;
@@ -102,7 +104,7 @@ Real get_binary_bh_psi(const RealVect &loc, const PoissonParameters &a_params)
     RealVect loc_bh2 = loc;
     Real rbh2 = get_bh_radius(loc_bh2, a_params.bh2_offset);
 
-    return m1 / rbh1 + m2 / rbh2;
+    return 0.5 * (m1 / rbh1 + m2 / rbh2);
 }
 
 #endif /* SETBINARYBH_HPP */


### PR DESCRIPTION
This is now more consistent with Alcubierre p112 eq. (3.4.29). Also add
in missing factor of 2 in Brill-Lindquist part of psi.